### PR TITLE
Updates main.lua, replaces deprecated push.q with push.quit

### DIFF
--- a/main.lua
+++ b/main.lua
@@ -31,7 +31,7 @@ end
 function love.keypressed(key)
     
     if key == 'escape' then
-        love.event.push('q')
+        love.event.push('quit')
     end
         
     if key == 'space' then


### PR DESCRIPTION
push.q is removed in LÖVE 0.7.2, and pressing ESC during game play leads to an "unknown event q" error message. This commit fixes it by using push.quit instead.